### PR TITLE
Add run-dredd-command hook

### DIFF
--- a/extensions/roc-plugin-dredd/src/actions/dredd.js
+++ b/extensions/roc-plugin-dredd/src/actions/dredd.js
@@ -1,35 +1,17 @@
-import { initLog } from 'roc';
 import { registerAction } from 'roc/lib/hooks/manageActions';
 
-import Dredd from '../dredd';
+import { invokeHook, name } from '../roc/util';
 
-const { name, version } = require('../../package.json');
+import serverStartedAction from './server-started';
 
-const log = initLog(name, version);
-
-export default ({ context }, watch) => (port, path) => () => {
-    const { verbose, config: { settings } } = context;
-
-    // Make it possible to override reporter using _raw
-    const options = {
-        ...settings.test.dredd,
-        silent: true, // We need to set this to silent to disable the default CLI reporter
-        reporter: settings.test.dredd.reporter || [],
-        verbose, // We introduce this option to enable verbosity
-    };
-
-    const dredd = new Dredd({
-        server: `http://localhost:${port}${path}`,
-        options,
-    }, log);
-
-    registerAction(({ hook }) => {
-        if (hook !== 'dev-process-stopping') {
-            return;
+export default () => (watch) => {
+    registerAction((action) => {
+        if (action.hook !== 'server-started') {
+            return null;
         }
 
-        dredd.cancel();
-    }, 'roc-plugin-dredd');
+        return serverStartedAction(action, watch);
+    }, name);
 
-    dredd.run(watch);
+    invokeHook('run-dev-command', ['node']);
 };

--- a/extensions/roc-plugin-dredd/src/actions/server-started.js
+++ b/extensions/roc-plugin-dredd/src/actions/server-started.js
@@ -1,0 +1,35 @@
+import { initLog } from 'roc';
+import { registerAction } from 'roc/lib/hooks/manageActions';
+
+import Dredd from '../dredd';
+
+const { name, version } = require('../../package.json');
+
+const log = initLog(name, version);
+
+export default ({ context }, watch) => (port, path) => () => {
+    const { verbose, config: { settings } } = context;
+
+    // Make it possible to override reporter using _raw
+    const options = {
+        ...settings.test.dredd,
+        silent: true, // We need to set this to silent to disable the default CLI reporter
+        reporter: settings.test.dredd.reporter || [],
+        verbose, // We introduce this option to enable verbosity
+    };
+
+    const dredd = new Dredd({
+        server: `http://localhost:${port}${path}`,
+        options,
+    }, log);
+
+    registerAction(({ hook }) => {
+        if (hook !== 'dev-process-stopping') {
+            return;
+        }
+
+        dredd.cancel();
+    }, 'roc-plugin-dredd');
+
+    dredd.run(watch);
+};

--- a/extensions/roc-plugin-dredd/src/commands/dredd.js
+++ b/extensions/roc-plugin-dredd/src/commands/dredd.js
@@ -1,14 +1,5 @@
-import { setActions, registerActions } from 'roc/lib/hooks/manageActions';
-
-import { invokeHook, name } from '../roc/util';
-import dreddAction from '../actions/dredd';
+import { invokeHook } from '../roc/util';
 
 export default function dredd({ options: { managed: managedOptions } }) {
-    setActions(registerActions([{
-        hook: 'server-started',
-        description: 'Run dredd tests',
-        action: (context) => dreddAction(context, managedOptions.watch),
-    }], name));
-
-    invokeHook('run-dev-command', ['node']);
+    invokeHook('run-dredd-command', managedOptions.watch || false);
 }

--- a/extensions/roc-plugin-dredd/src/roc/index.js
+++ b/extensions/roc-plugin-dredd/src/roc/index.js
@@ -1,5 +1,5 @@
 import { lazyFunctionRequire } from 'roc';
-import { isBoolean } from 'roc/validators';
+import { isBoolean, required, notEmpty } from 'roc/validators';
 
 import config from '../config/roc.config.js';
 import meta from '../config/roc.config.meta.js';
@@ -9,6 +9,13 @@ const lazyRequire = lazyFunctionRequire(require);
 export default {
     config,
     meta,
+    actions: [
+        {
+            hook: 'run-dredd-command',
+            description: 'Run dredd command',
+            action: lazyRequire('../actions/dredd'),
+        },
+    ],
     commands: {
         development: {
             dredd: {
@@ -27,6 +34,15 @@ export default {
         },
     },
     hooks: {
+        'run-dredd-command': {
+            description: 'Used to run the dredd command',
+            arguments: {
+                watch: {
+                    validator: required(notEmpty(isBoolean)),
+                    description: 'Run dredd in watch mode',
+                },
+            },
+        },
         'run-dev-command': {
             description: 'Used to start dev server used for dredd testing',
         },


### PR DESCRIPTION
Add run-dredd-command hook making it possible to execute actions before dredd testing starts.