### PR TITLE
Update dredd dependency to support swagger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache:
   directories:
     - node_modules
 node_js:
-  - 4.2
+  - 6.11.3
 before_install:
   - npm install -g npm
 before_script:

--- a/extensions/roc-plugin-dredd/package.json
+++ b/extensions/roc-plugin-dredd/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.3",
-    "dredd": "^3.2.2",
+    "dredd": "^4.6.2",
     "roc": "^1.0.0-rc.11"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates Dredd dependency to ^4.6.2.
This must be done to add support for Swagger schemas/OpenAPI.

Tested with both api blueprint and swagger api definitions.